### PR TITLE
Handle nil result from (find (vim.fn.getcwd))

### DIFF
--- a/fnl/nfnl/config.fnl
+++ b/fnl/nfnl/config.fnl
@@ -49,9 +49,10 @@
                    (core.get opts :root-dir)
 
                    ;; The closest .nfnl.fnl file parent directory to the cwd.
-                   (string.sub
-                     (fs.full-path (fs.basename (find (vim.fn.getcwd))))
-                     1 -2)
+                   (-?> (vim.fn.getcwd)
+                        (find) ; returns nil if .nfnl.fnl is not found
+                        (fs.full-path)
+                        (string.sub 1 -2))
 
                    ;; The cwd, just in case nothing else works.
                    (vim.fn.getcwd))


### PR DESCRIPTION
if the path returned by `(vim.fn.getcwd)` does not have an ancestor containing an .nfnl.fnl file, `(find (vim.fn.getcwd))` will return nil, which is not a valid input to string.sub.