### PR TITLE
Add doc strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ experience.
 [plug]: https://github.com/junegunn/vim-plug
 [packer]: https://github.com/wbthomason/packer.nvim
 [lazy]: https://github.com/folke/lazy.nvim
-[fenneldoc]: https://github.com/andreyorst/fenneldoc
+[fenneldoc]: https://gitlab.com/andreyorst/fenneldoc
 [telescope]: https://github.com/nvim-telescope/telescope.nvim
 [neotree]: https://github.com/nvim-neo-tree/neo-tree.nvim
 [astronvim]: https://astronvim.com/

--- a/docs/api/nfnl/compile.md
+++ b/docs/api/nfnl/compile.md
@@ -10,7 +10,7 @@
 Function signature:
 
 ```
-(all-files {:cfg cfg :root-dir root-dir})
+(all-files {:cfg cfg :root-dir root-dir &as opts})
 ```
 
 **Undocumented**
@@ -28,7 +28,7 @@ Function signature:
 Function signature:
 
 ```
-(into-string {:batch? batch? :cfg cfg :path path :root-dir root-dir :source source})
+(into-string {:batch? batch? :cfg cfg :file-exists-on-disk? file-exists-on-disk? :path path :root-dir root-dir :source source &as opts})
 ```
 
 **Undocumented**

--- a/docs/api/nfnl/core.md
+++ b/docs/api/nfnl/core.md
@@ -60,7 +60,12 @@ Function signature:
 (assoc t ...)
 ```
 
-**Undocumented**
+Set the key `k` in table `t` to the value `v` while safely handling `nil`.
+
+   Accepts more `k` and `v` pairs as after the initial pair. This allows you
+   to assoc multiple values in one call.
+
+   Returns the table `t` once it has been mutated.
 
 ## `assoc-in`
 Function signature:
@@ -69,7 +74,9 @@ Function signature:
 (assoc-in t ks v)
 ```
 
-**Undocumented**
+Set the key path `ks` in table `t` to the value `v` while safely handling `nil`.
+
+   `(assoc-in {:foo {:bar 10}} [:foo :bar] 15) // => {:foo {:bar 15}}`
 
 ## `boolean?`
 Function signature:
@@ -87,7 +94,7 @@ Function signature:
 (butlast xs)
 ```
 
-**Undocumented**
+Return every value from the sequential table except the last one.
 
 ## `complement`
 Function signature:
@@ -96,7 +103,8 @@ Function signature:
 (complement f)
 ```
 
-**Undocumented**
+Takes a fn `f` and returns a fn that takes the same arguments as `f`, has
+   the same effects, if any, and returns the opposite truth value.
 
 ## `concat`
 Function signature:
@@ -114,7 +122,7 @@ Function signature:
 (constantly v)
 ```
 
-**Undocumented**
+Returns a function that takes any number of arguments and returns `v`.
 
 ## `count`
 Function signature:
@@ -159,7 +167,7 @@ Function signature:
 (even? n)
 ```
 
-**Undocumented**
+True if `n` is even.
 
 ## `filter`
 Function signature:
@@ -177,7 +185,7 @@ Function signature:
 (first xs)
 ```
 
-**Undocumented**
+The first item of the sequential table.
 
 ## `function?`
 Function signature:
@@ -195,7 +203,8 @@ Function signature:
 (get t k d)
 ```
 
-**Undocumented**
+Get the key `k` from table `t` while safely handling `nil`. If it's not
+   found it will return the optional default value `d`.
 
 ## `get-in`
 Function signature:
@@ -204,7 +213,10 @@ Function signature:
 (get-in t ks d)
 ```
 
-**Undocumented**
+Get the key path `ks` from table `t` while safely handling `nil`. If it's
+   not found it will return the optional default value `d`.
+
+   `(get-in {:foo {:bar 10}} [:foo :bar]) // => 10`
 
 ## `identity`
 Function signature:
@@ -249,7 +261,7 @@ Function signature:
 (last xs)
 ```
 
-**Undocumented**
+The last item of the sequential table.
 
 ## `map`
 Function signature:
@@ -276,7 +288,7 @@ Function signature:
 (mapcat f xs)
 ```
 
-**Undocumented**
+The same as `map` but then `concat` all lists within the result together.
 
 ## `merge`
 Function signature:
@@ -285,7 +297,9 @@ Function signature:
 (merge ...)
 ```
 
-**Undocumented**
+Merge the tables together, `nil` will be skipped safely so you can use
+   `(when ...)` to conditionally include tables. Merges into a fresh table so
+   no existing tables will be mutated.
 
 ## `merge!`
 Function signature:
@@ -294,7 +308,8 @@ Function signature:
 (merge! base ...)
 ```
 
-**Undocumented**
+The same as `merge` above but will mutate the first argument, so all
+   tables are merged into the first one.
 
 ## `nil?`
 Function signature:
@@ -321,7 +336,7 @@ Function signature:
 (odd? n)
 ```
 
-**Undocumented**
+True if `n` is odd.
 
 ## `pr`
 Function signature:
@@ -330,7 +345,7 @@ Function signature:
 (pr ...)
 ```
 
-**Undocumented**
+Print the arguments as data, strings will remain quoted.
 
 ## `pr-str`
 Function signature:
@@ -339,7 +354,7 @@ Function signature:
 (pr-str ...)
 ```
 
-**Undocumented**
+Convert the input arguments to a string.
 
 ## `println`
 Function signature:
@@ -348,7 +363,7 @@ Function signature:
 (println ...)
 ```
 
-**Undocumented**
+Convert the input arguments to a string (if required) and print them.
 
 ## `rand`
 Function signature:
@@ -358,7 +373,7 @@ Function signature:
 ```
 
 Draw a random floating point number between 0 and `n`, where `n` is 1.0 if omitted.
-  You must have a random seed set before running this: (math.randomseed (os.time))
+  You must have a random seed set before running this: `(math.randomseed (os.time))`
 
 ## `reduce`
 Function signature:
@@ -377,7 +392,8 @@ Function signature:
 (remove f xs)
 ```
 
-**Undocumented**
+Opposite of filter, filter `xs` down to a new sequential table containing
+   every value that `(f x)` returned falsy for.
 
 ## `rest`
 Function signature:
@@ -386,7 +402,7 @@ Function signature:
 (rest xs)
 ```
 
-**Undocumented**
+Return every value from the sequential table except the first one.
 
 ## `run!`
 Function signature:
@@ -404,7 +420,7 @@ Function signature:
 (second xs)
 ```
 
-**Undocumented**
+The second item of the sequential table.
 
 ## `select-keys`
 Function signature:
@@ -413,7 +429,7 @@ Function signature:
 (select-keys t ks)
 ```
 
-**Undocumented**
+Extract the keys listed in `ks` from `t` and return it as a new table.
 
 ## `slurp`
 Function signature:
@@ -458,7 +474,8 @@ Function signature:
 (str ...)
 ```
 
-**Undocumented**
+Concatenate the values into one string. Converting non-string values into
+   strings where required.
 
 ## `string?`
 Function signature:
@@ -485,7 +502,8 @@ Function signature:
 (update t k f)
 ```
 
-**Undocumented**
+Replace the key `k` in table `t` by passing the current value through the
+   function `f`. Returns the table after the key has been mutated.
 
 ## `update-in`
 Function signature:
@@ -494,7 +512,8 @@ Function signature:
 (update-in t ks f)
 ```
 
-**Undocumented**
+Same as `update` but replace the key path at `ks` with the result of
+   passing the current value through the function `f`.
 
 ## `vals`
 Function signature:

--- a/docs/api/nfnl/fs.md
+++ b/docs/api/nfnl/fs.md
@@ -2,6 +2,7 @@
 
 **Table of contents**
 
+- [`absglob`](#absglob)
 - [`basename`](#basename)
 - [`file-name-root`](#file-name-root)
 - [`filename`](#filename)
@@ -17,6 +18,15 @@
 - [`replace-dirs`](#replace-dirs)
 - [`replace-extension`](#replace-extension)
 - [`split-path`](#split-path)
+
+## `absglob`
+Function signature:
+
+```
+(absglob dir expr)
+```
+
+Glob all files under dir matching the expression and return the absolute paths.
 
 ## `basename`
 Function signature:

--- a/fnl/nfnl/core.fnl
+++ b/fnl/nfnl/core.fnl
@@ -3,7 +3,7 @@
 
 (fn rand [n]
   "Draw a random floating point number between 0 and `n`, where `n` is 1.0 if omitted.
-  You must have a random seed set before running this: (math.randomseed (os.time))"
+  You must have a random seed set before running this: `(math.randomseed (os.time))`"
   (* (math.random) (or n 1)))
 
 (fn nil? [x]
@@ -54,14 +54,17 @@
   (= 0 (count xs)))
 
 (fn first [xs]
+  "The first item of the sequential table."
   (when xs
     (. xs 1)))
 
 (fn second [xs]
+  "The second item of the sequential table."
   (when xs
     (. xs 2)))
 
 (fn last [xs]
+  "The last item of the sequential table."
   (when xs
     (. xs (count xs))))
 
@@ -74,9 +77,11 @@
   (- n 1))
 
 (fn even? [n]
+  "True if `n` is even."
   (= (% n 2) 0))
 
 (fn odd? [n]
+  "True if `n` is odd."
   (not (even? n)))
 
 (fn vals [t]
@@ -104,6 +109,8 @@
           (f (. xs i)))))))
 
 (fn complement [f]
+  "Takes a fn `f` and returns a fn that takes the same arguments as `f`, has
+   the same effects, if any, and returns the opposite truth value."
   (fn [...]
     (not (f ...))))
 
@@ -118,6 +125,8 @@
     result))
 
 (fn remove [f xs]
+  "Opposite of filter, filter `xs` down to a new sequential table containing
+   every value that `(f x)` returned falsy for."
   (filter (complement f) xs))
 
 (fn map [f xs]
@@ -164,6 +173,7 @@
   result)
 
 (fn butlast [xs]
+  "Return every value from the sequential table except the last one."
   (let [total (count xs)]
     (->> (kv-pairs xs)
          (filter
@@ -172,6 +182,7 @@
          (map second))))
 
 (fn rest [xs]
+  "Return every value from the sequential table except the first one."
   (->> (kv-pairs xs)
        (filter
          (fn [[n v]]
@@ -190,9 +201,11 @@
     result))
 
 (fn mapcat [f xs]
+  "The same as `map` but then `concat` all lists within the result together."
   (concat (unpack (map f xs))))
 
 (fn pr-str [...]
+  "Convert the input arguments to a string."
   (let [s (table.concat
             (map (fn [x]
                    (fennel.view x {:one-line true}))
@@ -203,6 +216,8 @@
       s)))
 
 (fn str [...]
+  "Concatenate the values into one string. Converting non-string values into
+   strings where required."
   (->> [...]
        (map
          (fn [s]
@@ -215,6 +230,7 @@
          "")))
 
 (fn println [...]
+  "Convert the input arguments to a string (if required) and print them."
   (->> [...]
        (map
          (fn [s]
@@ -233,6 +249,7 @@
        print))
 
 (fn pr [...]
+  "Print the arguments as data, strings will remain quoted."
   (println (pr-str ...)))
 
 (fn slurp [path]
@@ -245,6 +262,8 @@
           content))))
 
 (fn get [t k d]
+  "Get the key `k` from table `t` while safely handling `nil`. If it's not
+   found it will return the optional default value `d`."
   (let [res (when (table? t)
               (let [val (. t k)]
                 (when (not (nil? val))
@@ -268,6 +287,8 @@
           nil))))
 
 (fn merge! [base ...]
+  "The same as `merge` above but will mutate the first argument, so all
+   tables are merged into the first one."
   (reduce
     (fn [acc m]
       (when m
@@ -278,9 +299,13 @@
     [...]))
 
 (fn merge [...]
+  "Merge the tables together, `nil` will be skipped safely so you can use
+   `(when ...)` to conditionally include tables. Merges into a fresh table so
+   no existing tables will be mutated."
   (merge! {} ...))
 
 (fn select-keys [t ks]
+  "Extract the keys listed in `ks` from `t` and return it as a new table."
   (if (and t ks)
     (reduce
       (fn [acc k]
@@ -292,6 +317,10 @@
     {}))
 
 (fn get-in [t ks d]
+  "Get the key path `ks` from table `t` while safely handling `nil`. If it's
+   not found it will return the optional default value `d`.
+
+   `(get-in {:foo {:bar 10}} [:foo :bar]) // => 10`"
   (let [res (reduce
               (fn [acc k]
                 (when (table? acc)
@@ -302,6 +331,12 @@
       res)))
 
 (fn assoc [t ...]
+  "Set the key `k` in table `t` to the value `v` while safely handling `nil`.
+
+   Accepts more `k` and `v` pairs as after the initial pair. This allows you
+   to assoc multiple values in one call.
+
+   Returns the table `t` once it has been mutated."
   (let [[k v & xs] [...]
         rem (count xs)
         t (or t {})]
@@ -318,6 +353,9 @@
     t))
 
 (fn assoc-in [t ks v]
+  "Set the key path `ks` in table `t` to the value `v` while safely handling `nil`.
+
+   `(assoc-in {:foo {:bar 10}} [:foo :bar] 15) // => {:foo {:bar 15}}`"
   (let [path (butlast ks)
         final (last ks)
         t (or t {})]
@@ -334,12 +372,17 @@
     t))
 
 (fn update [t k f]
+  "Replace the key `k` in table `t` by passing the current value through the
+   function `f`. Returns the table after the key has been mutated."
   (assoc t k (f (get t k))))
 
 (fn update-in [t ks f]
+  "Same as `update` but replace the key path at `ks` with the result of
+   passing the current value through the function `f`."
   (assoc-in t ks (f (get-in t ks))))
 
 (fn constantly [v]
+  "Returns a function that takes any number of arguments and returns `v`."
   (fn [] v))
 
 (fn distinct [xs]


### PR DESCRIPTION
A first pass at issue #22 :
- I just updated `nfnl/core.fnl` by copying the info from Aniseed's help doc.
- The docs for `nfnl/compile.fnl` and `nfnl/fs.fnl` were automatically updated as a result of generating the docs using `script/render-api-documentation`.
- I also updated the link to Andrey Listopadov's `fenneldoc` repo.