### PR TITLE
fix: basedir for .nfnl file

### DIFF
--- a/fnl/nfnl/config.fnl
+++ b/fnl/nfnl/config.fnl
@@ -52,7 +52,7 @@
                    (-?> (vim.fn.getcwd)
                         (find) ; returns nil if .nfnl.fnl is not found
                         (fs.full-path)
-                        (string.sub 1 -2))
+                        (fs.basename))
 
                    ;; The cwd, just in case nothing else works.
                    (vim.fn.getcwd))

--- a/lua/nfnl/config.lua
+++ b/lua/nfnl/config.lua
@@ -32,7 +32,7 @@ local function default(opts)
       if (nil ~= _8_) then
         local _9_ = fs["full-path"](_8_)
         if (nil ~= _9_) then
-          return string.sub(_9_, 1, -2)
+          return fs.basename(_9_)
         else
           return _9_
         end


### PR DESCRIPTION
as title says, basedir is missing and will return XXX/.nfnl.fn.
also notice basedir return will not end with /, so not need string.sub