### PR TITLE
fix: clear loaded macro cache so code will use new macro

### DIFF
--- a/fnl/nfnl/compile.fnl
+++ b/fnl/nfnl/compile.fnl
@@ -38,7 +38,11 @@
        :source-path path}
 
       macro?
-      (mod.all-files {: root-dir : cfg})
+      (do
+        ; clear loaded macro cache so it will import new
+        (let [t fennel.macro-loaded]
+          (each [k _ (pairs t)] (tset t k nil)))
+        (mod.all-files {: root-dir : cfg}))
 
       (config.config-file-path? path)
       {:status :nfnl-config-is-not-compiled

--- a/lua/nfnl/compile.lua
+++ b/lua/nfnl/compile.lua
@@ -40,6 +40,12 @@ mod["into-string"] = function(_5_)
   if (macro_3f and batch_3f) then
     return {status = "macros-are-not-compiled", ["source-path"] = path}
   elseif macro_3f then
+    do
+      local t = fennel["macro-loaded"]
+      for k, _ in pairs(t) do
+        t[k] = nil
+      end
+    end
     return mod["all-files"]({["root-dir"] = root_dir, cfg = cfg})
   elseif config["config-file-path?"](path) then
     return {status = "nfnl-config-is-not-compiled", ["source-path"] = path}


### PR DESCRIPTION
Reproduce Step:

* a fnl file(named A) with macro import get compiled.
* modify this macro file to add a new macro
* use the new macro in file A.
* save it will fail as A not visible the new change.

To make macro changes works immediately, this patch clear the loaded macro cache when it find it changes. 