### PR TITLE
Improve globbing behavior for single-file compilation

### DIFF
--- a/docs/api/nfnl/compile.md
+++ b/docs/api/nfnl/compile.md
@@ -28,7 +28,7 @@ Function signature:
 Function signature:
 
 ```
-(into-string {:batch? batch? :cfg cfg :file-exists-on-disk? file-exists-on-disk? :path path :root-dir root-dir :source source &as opts})
+(into-string {:batch? batch? :cfg cfg :path path :root-dir root-dir :source source &as opts})
 ```
 
 **Undocumented**

--- a/docs/api/nfnl/fs.md
+++ b/docs/api/nfnl/fs.md
@@ -10,6 +10,7 @@
 - [`fnl-path->lua-path`](#fnl-path-lua-path)
 - [`full-path`](#full-path)
 - [`glob-dir-newer?`](#glob-dir-newer)
+- [`glob-matches?`](#glob-matches)
 - [`join-path`](#join-path)
 - [`mkdirp`](#mkdirp)
 - [`path-sep`](#path-sep)
@@ -91,6 +92,15 @@ Function signature:
 ```
 
 Returns true if a-dir has newer changes than b-dir. All paths from a-dir are mapped through b-dir-path-fn before comparing to b-dir.
+
+## `glob-matches?`
+Function signature:
+
+```
+(glob-matches? dir expr path)
+```
+
+Return true if path matches the glob expression. The path should be absolute and the glob should be relative to dir.
 
 ## `join-path`
 Function signature:

--- a/fnl/nfnl/fs.fnl
+++ b/fnl/nfnl/fs.fnl
@@ -1,6 +1,7 @@
 (local {: autoload} (require :nfnl.module))
 (local core (autoload :nfnl.core))
 (local str (autoload :nfnl.string))
+(local notify (autoload :nfnl.notify))
 
 (fn basename [path]
   "Remove the file part of the path."
@@ -95,6 +96,11 @@
       (replace-extension "lua")
       (replace-dirs "fnl" "lua")))
 
+(fn glob-matches? [dir expr path]
+  "Return true if path matches the glob expression. The path should be absolute and the glob should be relative to dir."
+  (let [regex (vim.regex (vim.fn.glob2regpat (join-path [dir expr])))]
+    (regex:match_str path)))
+
 {: basename
  : filename
  : file-name-root
@@ -110,4 +116,5 @@
  : join-path
  : read-first-line
  : replace-dirs
- : fnl-path->lua-path}
+ : fnl-path->lua-path
+ : glob-matches?}

--- a/fnl/spec/nfnl/compile_spec.fnl
+++ b/fnl/spec/nfnl/compile_spec.fnl
@@ -17,7 +17,19 @@
                :path "/tmp/foo/bar.fnl"
                :cfg (config.cfg-fn {} {:root-dir "/tmp/foo"})
                :batch? true
-               :file-exists-on-disk? false
+               :source "(+ 10 20)"}))))
+
+    (it "skips files that don't match :source-file-patterns"
+        (fn []
+          (assert.are.same
+            {:source-path "/my/dir/baz.fnl"
+             :status "path-is-not-in-source-file-patterns"}
+            (compile.into-string
+              {:root-dir "/my/dir"
+               :path "/my/dir/baz.fnl"
+               :cfg (config.cfg-fn {:source-file-patterns ["bar.fnl"]}
+                                   {:root-dir "/tmp/foo"})
+               :batch? true
                :source "(+ 10 20)"}))))
 
     (it "skips macro files"
@@ -30,7 +42,6 @@
                :path "/my/dir/foo.fnl"
                :cfg (config.cfg-fn {} {:root-dir "/tmp/foo"})
                :batch? true
-               :file-exists-on-disk? false
                :source (.. "; [nfnl" "-" "macro]\n(+ 10 20)")}))))
 
     (it "won't compile the .nfnl.fnl config file"
@@ -43,7 +54,6 @@
                :path "/my/dir/.nfnl.fnl"
                :cfg (config.cfg-fn {} {:root-dir "/tmp/foo"})
                :batch? true
-               :file-exists-on-disk? false
                :source "(+ 10 20)"}))))
 
     (it "returns compilation errors"
@@ -57,5 +67,4 @@
                :path "/my/dir/foo.fnl"
                :cfg (config.cfg-fn {} {:root-dir "/tmp/foo"})
                :batch? true
-               :file-exists-on-disk? false
                :source "10 / 20"}))))))

--- a/lua/nfnl/fs.lua
+++ b/lua/nfnl/fs.lua
@@ -3,6 +3,7 @@ local _local_1_ = require("nfnl.module")
 local autoload = _local_1_["autoload"]
 local core = autoload("nfnl.core")
 local str = autoload("nfnl.string")
+local notify = autoload("nfnl.notify")
 local function basename(path)
   if path then
     return vim.fn.fnamemodify(path, ":h")
@@ -110,4 +111,8 @@ end
 local function fnl_path__3elua_path(fnl_path)
   return replace_dirs(replace_extension(fnl_path, "lua"), "fnl", "lua")
 end
-return {basename = basename, filename = filename, ["file-name-root"] = file_name_root, ["full-path"] = full_path, mkdirp = mkdirp, ["replace-extension"] = replace_extension, absglob = absglob, relglob = relglob, ["glob-dir-newer?"] = glob_dir_newer_3f, ["path-sep"] = path_sep, findfile = findfile, ["split-path"] = split_path, ["join-path"] = join_path, ["read-first-line"] = read_first_line, ["replace-dirs"] = replace_dirs, ["fnl-path->lua-path"] = fnl_path__3elua_path}
+local function glob_matches_3f(dir, expr, path)
+  local regex = vim.regex(vim.fn.glob2regpat(join_path({dir, expr})))
+  return regex:match_str(path)
+end
+return {basename = basename, filename = filename, ["file-name-root"] = file_name_root, ["full-path"] = full_path, mkdirp = mkdirp, ["replace-extension"] = replace_extension, absglob = absglob, relglob = relglob, ["glob-dir-newer?"] = glob_dir_newer_3f, ["path-sep"] = path_sep, findfile = findfile, ["split-path"] = split_path, ["join-path"] = join_path, ["read-first-line"] = read_first_line, ["replace-dirs"] = replace_dirs, ["fnl-path->lua-path"] = fnl_path__3elua_path, ["glob-matches?"] = glob_matches_3f}

--- a/lua/spec/nfnl/compile_spec.lua
+++ b/lua/spec/nfnl/compile_spec.lua
@@ -7,20 +7,24 @@ local config = require("nfnl.config")
 local compile = require("nfnl.compile")
 local function _2_()
   local function _3_()
-    return assert.are.same({result = "-- [nfnl] Compiled from bar.fnl by https://github.com/Olical/nfnl, do not edit.\nreturn (10 + 20)\n", ["source-path"] = "/tmp/foo/bar.fnl", status = "ok"}, compile["into-string"]({["root-dir"] = "/tmp/foo", path = "/tmp/foo/bar.fnl", cfg = config["cfg-fn"]({}, {["root-dir"] = "/tmp/foo"}), ["batch?"] = true, source = "(+ 10 20)", ["file-exists-on-disk?"] = false}))
+    return assert.are.same({result = "-- [nfnl] Compiled from bar.fnl by https://github.com/Olical/nfnl, do not edit.\nreturn (10 + 20)\n", ["source-path"] = "/tmp/foo/bar.fnl", status = "ok"}, compile["into-string"]({["root-dir"] = "/tmp/foo", path = "/tmp/foo/bar.fnl", cfg = config["cfg-fn"]({}, {["root-dir"] = "/tmp/foo"}), ["batch?"] = true, source = "(+ 10 20)"}))
   end
   it("compiles good Fennel to Lua", _3_)
   local function _4_()
-    return assert.are.same({["source-path"] = "/my/dir/foo.fnl", status = "macros-are-not-compiled"}, compile["into-string"]({["root-dir"] = "/my/dir", path = "/my/dir/foo.fnl", cfg = config["cfg-fn"]({}, {["root-dir"] = "/tmp/foo"}), ["batch?"] = true, source = ("; [nfnl" .. "-" .. "macro]\n(+ 10 20)"), ["file-exists-on-disk?"] = false}))
+    return assert.are.same({["source-path"] = "/my/dir/baz.fnl", status = "path-is-not-in-source-file-patterns"}, compile["into-string"]({["root-dir"] = "/my/dir", path = "/my/dir/baz.fnl", cfg = config["cfg-fn"]({["source-file-patterns"] = {"bar.fnl"}}, {["root-dir"] = "/tmp/foo"}), ["batch?"] = true, source = "(+ 10 20)"}))
   end
-  it("skips macro files", _4_)
+  it("skips files that don't match :source-file-patterns", _4_)
   local function _5_()
-    return assert.are.same({["source-path"] = "/my/dir/.nfnl.fnl", status = "nfnl-config-is-not-compiled"}, compile["into-string"]({["root-dir"] = "/my/dir", path = "/my/dir/.nfnl.fnl", cfg = config["cfg-fn"]({}, {["root-dir"] = "/tmp/foo"}), ["batch?"] = true, source = "(+ 10 20)", ["file-exists-on-disk?"] = false}))
+    return assert.are.same({["source-path"] = "/my/dir/foo.fnl", status = "macros-are-not-compiled"}, compile["into-string"]({["root-dir"] = "/my/dir", path = "/my/dir/foo.fnl", cfg = config["cfg-fn"]({}, {["root-dir"] = "/tmp/foo"}), ["batch?"] = true, source = ("; [nfnl" .. "-" .. "macro]\n(+ 10 20)")}))
   end
-  it("won't compile the .nfnl.fnl config file", _5_)
+  it("skips macro files", _5_)
   local function _6_()
-    return assert.are.same({error = "/my/dir/foo.fnl:1:3: Compile error: tried to reference a special form without calling it\n\n10 / 20\n* Try making sure to use prefix operators, not infix.\n* Try wrapping the special in a function if you need it to be first class.", ["source-path"] = "/my/dir/foo.fnl", status = "compilation-error"}, compile["into-string"]({["root-dir"] = "/my/dir", path = "/my/dir/foo.fnl", cfg = config["cfg-fn"]({}, {["root-dir"] = "/tmp/foo"}), ["batch?"] = true, source = "10 / 20", ["file-exists-on-disk?"] = false}))
+    return assert.are.same({["source-path"] = "/my/dir/.nfnl.fnl", status = "nfnl-config-is-not-compiled"}, compile["into-string"]({["root-dir"] = "/my/dir", path = "/my/dir/.nfnl.fnl", cfg = config["cfg-fn"]({}, {["root-dir"] = "/tmp/foo"}), ["batch?"] = true, source = "(+ 10 20)"}))
   end
-  return it("returns compilation errors", _6_)
+  it("won't compile the .nfnl.fnl config file", _6_)
+  local function _7_()
+    return assert.are.same({error = "/my/dir/foo.fnl:1:3: Compile error: tried to reference a special form without calling it\n\n10 / 20\n* Try making sure to use prefix operators, not infix.\n* Try wrapping the special in a function if you need it to be first class.", ["source-path"] = "/my/dir/foo.fnl", status = "compilation-error"}, compile["into-string"]({["root-dir"] = "/my/dir", path = "/my/dir/foo.fnl", cfg = config["cfg-fn"]({}, {["root-dir"] = "/tmp/foo"}), ["batch?"] = true, source = "10 / 20"}))
+  end
+  return it("returns compilation errors", _7_)
 end
 return describe("into-string", _2_)


### PR DESCRIPTION
I recently migrated from Aniseed to nfnl and everything went great (thanks so much for these tools, by the way!). Then I started migrating my project-local config files for work, at which point I discovered that nfnl seemed to be hanging whenever I tried to save an `.nvim.fnl` file.

The behavior of globbing all compilable files on save works fine for a small to medium-size repo, but it's not great for the `.nvim.fnl` case in larger codebases with `node_modules` directories, Cargo caches, and so on. We can work around this in the single-file case by using `glob2regpat` and testing each glob against the file's path directly.

This isn't a perfect solution since it doesn't help with macros, but that seems like a bigger design challenge that's luckily not relevant for my `.nvim.fnl` files, and this at least seems like it shouldn't hurt. It also lets us get rid of the `file-exists-on-disk?` flag.