### PR TITLE
Orphan Lua file GC

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,17 @@ fine!) will default to these values that should work fine for most people.
  ;; Intended for users who wish to write shebang comments at the top of their .lua for easier execution.
  :header-comment true
 
- ;; Automatically invoke :NfnlFindOrphans whenever you write to a .fnl file. This acts as a passive garbage collection check and will warn you about dangling .lua files left over from .fnl deletions or renames.
- ;; If an orphan is found, you can use :NfnlDeleteOrphans to delete all of the files listed automatically. This command will NOT prompt you, so make sure you check the list first!
- :find-orphan-lua-files true
+ :orphan-detection
+ {;; Automatically invoke :NfnlFindOrphans whenever you write to a .fnl file. This acts as a passive
+  ;; garbage collection check and will warn you about dangling .lua files left over from .fnl deletions or renames.
+  ;; If an orphan is found, you can use :NfnlDeleteOrphans to delete all of the files listed
+  ;; automatically. The deletion command will NOT prompt you, so make sure you check the list first!
+  :auto? true
+
+  ;; If you embed nfnl, for example, in your Lua directory then nfnl will detect those files as orphans.
+  ;; You can add Lua patterns here to tell nfnl which Lua paths are okay and should not be counted as orphans.
+  ;; Example: ["lua/nfnl/"]
+  :ignore-patterns []}
 
  ;; Passed to fennel.compileString when your code is compiled.
  ;; See https://fennel-lang.org/api for more information.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ fine!) will default to these values that should work fine for most people.
  ;; Intended for users who wish to write shebang comments at the top of their .lua for easier execution.
  :header-comment true
 
+ ;; Automatically invoke :NfnlFindOrphans whenever you write to a .fnl file. This acts as a passive garbage collection check and will warn you about dangling .lua files left over from .fnl deletions or renames.
+ ;; If an orphan is found, you can use :NfnlDeleteOrphans to delete all of the files listed automatically. This command will NOT prompt you, so make sure you check the list first!
+ :find-orphan-lua-files true
+
  ;; Passed to fennel.compileString when your code is compiled.
  ;; See https://fennel-lang.org/api for more information.
  :compiler-options {;; Disables ansi escape sequences in compiler output.

--- a/fnl/nfnl/api.fnl
+++ b/fnl/nfnl/api.fnl
@@ -9,14 +9,15 @@
 
 (local M (define :nfnl.api))
 
-(fn M.find-orphans []
-  "Find orphan Lua files that were compiled from a Fennel file that no longer exists. Display them with notify."
+(fn M.find-orphans [opts]
+  "Find orphan Lua files that were compiled from a Fennel file that no longer exists. Display them with notify. Set opts.passive? to true if you don't want it to tell you that there are no orphans."
   (let [dir (vim.fn.getcwd)
         {: config : root-dir : cfg} (config.find-and-load dir)]
     (if config
       (let [orphan-files (gc.find-orphan-lua-files {: root-dir : cfg})]
         (if (core.empty? orphan-files)
-            (notify.info "No orphan files detected.")
+            (when (not (core.get opts :passive?))
+              (notify.info "No orphan files detected."))
             (notify.warn
               "Orphan files detected, delete them with :NfnlDeleteOrphans.\n"
               (->> orphan-files

--- a/fnl/nfnl/api.fnl
+++ b/fnl/nfnl/api.fnl
@@ -1,13 +1,13 @@
-(local {: autoload} (require :nfnl.module))
+(local {: autoload : define} (require :nfnl.module))
 (local core (autoload :nfnl.core))
 (local compile (autoload :nfnl.compile))
 (local config (autoload :nfnl.config))
 (local notify (autoload :nfnl.notify))
 (local fs (autoload :nfnl.fs))
 
-(local mod {})
+(local M (define :nfnl.api))
 
-(fn mod.compile-file [{: path : dir}]
+(fn M.compile-file [{: path : dir}]
   "Compiles a file into the matching Lua file. Returns the compilation result. Takes an optional `dir` key that changes the working directory.
 
   Will do nothing if you execute it on a directory that doesn't contain an nfnl configuration file.
@@ -29,7 +29,7 @@
         (notify.warn "No .nfnl.fnl configuration found.")
         []))))
 
-(fn mod.compile-all-files [dir]
+(fn M.compile-all-files [dir]
   "Compiles all files in the given dir (optional), defaulting to the current working directory. Returns a sequential table with each of the files compilation result.
 
   Will do nothing if you execute it on a directory that doesn't contain an nfnl configuration file.
@@ -45,8 +45,8 @@
         (notify.warn "No .nfnl.fnl configuration found.")
         []))))
 
-(fn mod.dofile [file]
+(fn M.dofile [file]
   "Just like :luafile, takes a Fennel file path (optional, defaults to '%', runs it through expand) and executes it from disk. However! This doesn't compile the Fennel! It maps the Fennel path to the matching Lua file already in your file system and executes that with Lua's built in dofile. So you need to have already written your .fnl and had nfnl compile that to a .lua for this to work, it's just a convinience function for you to call directly or through the :NfnlFile command."
   (dofile (fs.fnl-path->lua-path (vim.fn.expand (or file "%")))))
 
-mod
+M

--- a/fnl/nfnl/callback.fnl
+++ b/fnl/nfnl/callback.fnl
@@ -22,6 +22,10 @@
        : cfg
        :path (fs.full-path (. ev :file))
        :source (nvim.get-buf-content-as-string (. ev :buf))})
+
+    (when (cfg [:find-orphan-lua-files])
+      (api.find-orphans {:passive? true}))
+
     nil))
 
 (fn supported-path? [file-path]

--- a/fnl/nfnl/callback.fnl
+++ b/fnl/nfnl/callback.fnl
@@ -23,7 +23,7 @@
        :path (fs.full-path (. ev :file))
        :source (nvim.get-buf-content-as-string (. ev :buf))})
 
-    (when (cfg [:find-orphan-lua-files])
+    (when (cfg [:orphan-detection :auto?])
       (api.find-orphans {:passive? true}))
 
     nil))

--- a/fnl/nfnl/callback.fnl
+++ b/fnl/nfnl/callback.fnl
@@ -77,7 +77,19 @@
             {:desc "Executes (nfnl.api/compile-all-files) which will, you guessed it, compile all of your files."
              :force true
              :complete "file"
-             :nargs "?"}))))))
+             :nargs "?"})
+
+          (vim.api.nvim_buf_create_user_command
+            ev.buf :NfnlFindOrphans
+            #(api.find-orphans)
+            {:desc "Executes (nfnl.api/find-orphans) which will find and display all Lua files that no longer have a matching Fennel file."
+             :force true})
+
+          (vim.api.nvim_buf_create_user_command
+            ev.buf :NfnlDeleteOrphans
+            #(api.delete-orphans)
+            {:desc "Executes (nfnl.api/delete-orphans) deletes any orphan Lua files that no longer have their original Fennel file they were compiled from."
+             :force true}))))))
 
 {: fennel-filetype-callback
  : supported-path?}

--- a/fnl/nfnl/compile.fnl
+++ b/fnl/nfnl/compile.fnl
@@ -4,21 +4,16 @@
 (local fennel (autoload :nfnl.fennel))
 (local notify (autoload :nfnl.notify))
 (local config (autoload :nfnl.config))
+(local header (autoload :nfnl.header))
 
 (local mod {})
-
-(local header-marker "[nfnl]")
-
-(fn with-header [file src]
-  (.. "-- " header-marker " " file "\n" src))
 
 (fn safe-target? [path]
   "Reads the given file and checks if it contains our header marker on the
   first line. Returns true if it contains the marker, we're allowed to
   overwrite this file."
-  (let [header (fs.read-first-line path)]
-    (or (core.nil? header)
-        (not (core.nil? (header:find header-marker 1 true))))))
+  (let [line (fs.read-first-line path)]
+    (or (not line) (header.tagged? line))))
 
 (fn macro-source? [source]
   (string.find source "%s*;+%s*%[nfnl%-macro%]"))
@@ -74,7 +69,7 @@
             {:status :ok
              :source-path path
              :result (.. (if (cfg [:header-comment])
-                           (with-header rel-file-name res)
+                           (header.with-header rel-file-name res)
                            res)
                          "\n")})
           (do

--- a/fnl/nfnl/config.fnl
+++ b/fnl/nfnl/config.fnl
@@ -64,8 +64,9 @@
 
     {:verbose false
      :header-comment true
-     :find-orphan-lua-files true
      :compiler-options {:error-pinpoint false}
+     :orphan-detection {:auto? true
+                        :ignore-patterns []}
 
      :root-dir root-dir
 

--- a/fnl/nfnl/config.fnl
+++ b/fnl/nfnl/config.fnl
@@ -64,6 +64,7 @@
 
     {:verbose false
      :header-comment true
+     :find-orphan-lua-files true
      :compiler-options {:error-pinpoint false}
 
      :root-dir root-dir

--- a/fnl/nfnl/fs.fnl
+++ b/fnl/nfnl/fs.fnl
@@ -102,8 +102,10 @@
   (let [regex (vim.regex (vim.fn.glob2regpat (M.join-path [dir expr])))]
     (regex:match_str path)))
 
+(local uv (or vim.uv vim.loop))
+
 (fn M.exists? [path]
   (when path
-    (= "table" (type (vim.uv.fs_stat path)))))
+    (= "table" (type (uv.fs_stat path)))))
 
 M

--- a/fnl/nfnl/gc.fnl
+++ b/fnl/nfnl/gc.fnl
@@ -3,4 +3,7 @@
 
 (local M (define :nfnl.gc))
 
+(fn M.find-orphan-lua-files []
+  (fs.relglob "." "**/*.lua"))
+
 M

--- a/fnl/nfnl/gc.fnl
+++ b/fnl/nfnl/gc.fnl
@@ -1,0 +1,6 @@
+(local {: autoload : define} (require :nfnl.module))
+(local fs (autoload :nfnl.fs))
+
+(local M (define :nfnl.gc))
+
+M

--- a/fnl/nfnl/gc.fnl
+++ b/fnl/nfnl/gc.fnl
@@ -2,6 +2,7 @@
 (local core (autoload :nfnl.core))
 (local str (autoload :nfnl.string))
 (local fs (autoload :nfnl.fs))
+(local header (autoload :nfnl.header))
 
 (local M (define :nfnl.gc))
 
@@ -16,12 +17,9 @@
          (core.keys)
          (core.filter
            (fn [path]
-             ;; TODO This needs to share code with nfnl.compile.
-             ;; TODO Need to check if the header matches our pattern of [nfnl] file-path
-             (let [header (fs.read-first-line path)]
-               (and header
-                    (not (core.nil? (header:find "[nfnl]" 1 true)))
-                    (not (vim.uv.fs_stat (core.last (str.split path "%s+")))))))))))
+             (let [line (fs.read-first-line path)]
+               (and (header.tagged? line)
+                    (not (fs.exists? (header.source-path line))))))))))
 
 (comment
   (local config (require :nfnl.config))

--- a/fnl/nfnl/gc.fnl
+++ b/fnl/nfnl/gc.fnl
@@ -1,9 +1,30 @@
 (local {: autoload : define} (require :nfnl.module))
+(local core (autoload :nfnl.core))
+(local str (autoload :nfnl.string))
 (local fs (autoload :nfnl.fs))
 
 (local M (define :nfnl.gc))
 
-(fn M.find-orphan-lua-files []
-  (fs.relglob "." "**/*.lua"))
+(fn M.find-orphan-lua-files [{: cfg : root-dir}]
+  (let [fnl-path->lua-path (cfg [:fnl-path->lua-path])]
+    (->> (cfg [:source-file-patterns])
+         (core.mapcat
+           (fn [fnl-pattern]
+             (let [lua-pattern (fnl-path->lua-path fnl-pattern)]
+               (fs.absglob root-dir lua-pattern))))
+         (core.->set)
+         (core.keys)
+         (core.filter
+           (fn [path]
+             ;; TODO This needs to share code with nfnl.compile.
+             ;; TODO Need to check if the header matches our pattern of [nfnl] file-path
+             (let [header (fs.read-first-line path)]
+               (and header
+                    (not (core.nil? (header:find "[nfnl]" 1 true)))
+                    (not (vim.uv.fs_stat (core.last (str.split path "%s+")))))))))))
+
+(comment
+  (local config (require :nfnl.config))
+  (M.find-orphan-lua-files (config.find-and-load ".")))
 
 M

--- a/fnl/nfnl/gc.fnl
+++ b/fnl/nfnl/gc.fnl
@@ -1,6 +1,5 @@
 (local {: autoload : define} (require :nfnl.module))
 (local core (autoload :nfnl.core))
-(local str (autoload :nfnl.string))
 (local fs (autoload :nfnl.fs))
 (local header (autoload :nfnl.header))
 
@@ -12,7 +11,7 @@
          (core.mapcat
            (fn [fnl-pattern]
              (let [lua-pattern (fnl-path->lua-path fnl-pattern)]
-               (fs.absglob root-dir lua-pattern))))
+               (fs.relglob root-dir lua-pattern))))
          (core.->set)
          (core.keys)
          (core.filter

--- a/fnl/nfnl/gc.fnl
+++ b/fnl/nfnl/gc.fnl
@@ -6,7 +6,8 @@
 (local M (define :nfnl.gc))
 
 (fn M.find-orphan-lua-files [{: cfg : root-dir}]
-  (let [fnl-path->lua-path (cfg [:fnl-path->lua-path])]
+  (let [fnl-path->lua-path (cfg [:fnl-path->lua-path])
+        ignore-patterns (cfg [:orphan-detection :ignore-patterns])]
     (->> (cfg [:source-file-patterns])
          (core.mapcat
            (fn [fnl-pattern]
@@ -17,7 +18,11 @@
          (core.filter
            (fn [path]
              (let [line (fs.read-first-line path)]
-               (and (header.tagged? line)
+               (and (not (core.some
+                           (fn [pat]
+                             (path:find pat))
+                           ignore-patterns))
+                    (header.tagged? line)
                     (not (fs.exists? (header.source-path line))))))))))
 
 (comment

--- a/fnl/nfnl/header.fnl
+++ b/fnl/nfnl/header.fnl
@@ -1,5 +1,6 @@
 (local {: autoload : define} (require :nfnl.module))
 (local core (autoload :nfnl.core))
+(local str (autoload :nfnl.string))
 
 (local M (define :nfnl.header))
 
@@ -11,9 +12,10 @@
 
 (fn M.tagged? [s]
   "Is the line an nfnl tagged header line?"
-  (core.string? (s:find tag 1 true)))
+  (core.number? (s:find tag 1 true)))
 
-(fn M.source-path []
-  "")
+(fn M.source-path [s]
+  (when (M.tagged? s)
+    (core.last (str.split s "%s+"))))
 
 M

--- a/fnl/nfnl/header.fnl
+++ b/fnl/nfnl/header.fnl
@@ -1,0 +1,19 @@
+(local {: autoload : define} (require :nfnl.module))
+(local core (autoload :nfnl.core))
+
+(local M (define :nfnl.header))
+
+(local tag "[nfnl]")
+
+(fn M.with-header [file src]
+  "Return the source with an nfnl header prepended."
+  (.. "-- " tag " " file "\n" src))
+
+(fn M.tagged? [s]
+  "Is the line an nfnl tagged header line?"
+  (core.string? (s:find tag 1 true)))
+
+(fn M.source-path []
+  "")
+
+M

--- a/fnl/nfnl/header.fnl
+++ b/fnl/nfnl/header.fnl
@@ -16,6 +16,9 @@
 
 (fn M.source-path [s]
   (when (M.tagged? s)
-    (core.last (str.split s "%s+"))))
+    (core.some
+      (fn [part]
+        (and (str.ends-with? part ".fnl") part))
+      (str.split s "%s+"))))
 
 M

--- a/fnl/spec/nfnl/macros/aniseed_spec.fnl
+++ b/fnl/spec/nfnl/macros/aniseed_spec.fnl
@@ -63,4 +63,4 @@
     (it "defines public once values"
       (fn []
         (assert.equals "this is public once val" public-once-val)
-        (assert.equals "this is public once val" (. mod :public-once-val)))))
+        (assert.equals "this is public once val" (. mod :public-once-val))))))

--- a/lua/nfnl/api.lua
+++ b/lua/nfnl/api.lua
@@ -1,13 +1,14 @@
 -- [nfnl] fnl/nfnl/api.fnl
 local _local_1_ = require("nfnl.module")
 local autoload = _local_1_["autoload"]
+local define = _local_1_["define"]
 local core = autoload("nfnl.core")
 local compile = autoload("nfnl.compile")
 local config = autoload("nfnl.config")
 local notify = autoload("nfnl.notify")
 local fs = autoload("nfnl.fs")
-local mod = {}
-mod["compile-file"] = function(_2_)
+local M = define("nfnl.api")
+M["compile-file"] = function(_2_)
   local path = _2_["path"]
   local dir = _2_["dir"]
   local dir0 = (dir or vim.fn.getcwd())
@@ -25,7 +26,7 @@ mod["compile-file"] = function(_2_)
     return {}
   end
 end
-mod["compile-all-files"] = function(dir)
+M["compile-all-files"] = function(dir)
   local dir0 = (dir or vim.fn.getcwd())
   local _let_5_ = config["find-and-load"](dir0)
   local config0 = _let_5_["config"]
@@ -40,7 +41,7 @@ mod["compile-all-files"] = function(dir)
     return {}
   end
 end
-mod.dofile = function(file)
+M.dofile = function(file)
   return dofile(fs["fnl-path->lua-path"](vim.fn.expand((file or "%"))))
 end
-return mod
+return M

--- a/lua/nfnl/api.lua
+++ b/lua/nfnl/api.lua
@@ -10,7 +10,7 @@ local notify = autoload("nfnl.notify")
 local fs = autoload("nfnl.fs")
 local gc = autoload("nfnl.gc")
 local M = define("nfnl.api")
-M["find-orphans"] = function()
+M["find-orphans"] = function(opts)
   local dir = vim.fn.getcwd()
   local _let_2_ = config["find-and-load"](dir)
   local config0 = _let_2_["config"]
@@ -19,12 +19,15 @@ M["find-orphans"] = function()
   if config0 then
     local orphan_files = gc["find-orphan-lua-files"]({["root-dir"] = root_dir, cfg = cfg})
     if core["empty?"](orphan_files) then
-      notify.info("No orphan files detected.")
+      if not core.get(opts, "passive?") then
+        notify.info("No orphan files detected.")
+      else
+      end
     else
-      local function _3_(f)
+      local function _4_(f)
         return (" - " .. f)
       end
-      notify.warn("Orphan files detected, delete them with :NfnlDeleteOrphans.\n", str.join("\n", core.map(_3_, orphan_files)))
+      notify.warn("Orphan files detected, delete them with :NfnlDeleteOrphans.\n", str.join("\n", core.map(_4_, orphan_files)))
     end
     return orphan_files
   else
@@ -34,19 +37,19 @@ M["find-orphans"] = function()
 end
 M["delete-orphans"] = function()
   local dir = vim.fn.getcwd()
-  local _let_6_ = config["find-and-load"](dir)
-  local config0 = _let_6_["config"]
-  local root_dir = _let_6_["root-dir"]
-  local cfg = _let_6_["cfg"]
+  local _let_7_ = config["find-and-load"](dir)
+  local config0 = _let_7_["config"]
+  local root_dir = _let_7_["root-dir"]
+  local cfg = _let_7_["cfg"]
   if config0 then
     local orphan_files = gc["find-orphan-lua-files"]({["root-dir"] = root_dir, cfg = cfg})
     if core["empty?"](orphan_files) then
       notify.info("No orphan files detected.")
     else
-      local function _7_(f)
+      local function _8_(f)
         return (" - " .. f)
       end
-      notify.info("Deleting orphan files:\n", str.join("\n", core.map(_7_, orphan_files)))
+      notify.info("Deleting orphan files:\n", str.join("\n", core.map(_8_, orphan_files)))
       core.map(os.remove, orphan_files)
     end
     return orphan_files
@@ -55,14 +58,14 @@ M["delete-orphans"] = function()
     return {}
   end
 end
-M["compile-file"] = function(_10_)
-  local path = _10_["path"]
-  local dir = _10_["dir"]
+M["compile-file"] = function(_11_)
+  local path = _11_["path"]
+  local dir = _11_["dir"]
   local dir0 = (dir or vim.fn.getcwd())
-  local _let_11_ = config["find-and-load"](dir0)
-  local config0 = _let_11_["config"]
-  local root_dir = _let_11_["root-dir"]
-  local cfg = _let_11_["cfg"]
+  local _let_12_ = config["find-and-load"](dir0)
+  local config0 = _let_12_["config"]
+  local root_dir = _let_12_["root-dir"]
+  local cfg = _let_12_["cfg"]
   if config0 then
     local path0 = fs["join-path"]({root_dir, vim.fn.expand((path or "%"))})
     local result = compile["into-file"]({["root-dir"] = root_dir, cfg = cfg, path = path0, source = core.slurp(path0), ["batch?"] = true})
@@ -75,10 +78,10 @@ M["compile-file"] = function(_10_)
 end
 M["compile-all-files"] = function(dir)
   local dir0 = (dir or vim.fn.getcwd())
-  local _let_13_ = config["find-and-load"](dir0)
-  local config0 = _let_13_["config"]
-  local root_dir = _let_13_["root-dir"]
-  local cfg = _let_13_["cfg"]
+  local _let_14_ = config["find-and-load"](dir0)
+  local config0 = _let_14_["config"]
+  local root_dir = _let_14_["root-dir"]
+  local cfg = _let_14_["cfg"]
   if config0 then
     local results = compile["all-files"]({["root-dir"] = root_dir, cfg = cfg})
     notify.info("Compilation complete.\n", results)

--- a/lua/nfnl/api.lua
+++ b/lua/nfnl/api.lua
@@ -3,19 +3,66 @@ local _local_1_ = require("nfnl.module")
 local autoload = _local_1_["autoload"]
 local define = _local_1_["define"]
 local core = autoload("nfnl.core")
+local str = autoload("nfnl.string")
 local compile = autoload("nfnl.compile")
 local config = autoload("nfnl.config")
 local notify = autoload("nfnl.notify")
 local fs = autoload("nfnl.fs")
+local gc = autoload("nfnl.gc")
 local M = define("nfnl.api")
-M["compile-file"] = function(_2_)
-  local path = _2_["path"]
-  local dir = _2_["dir"]
+M["find-orphans"] = function()
+  local dir = vim.fn.getcwd()
+  local _let_2_ = config["find-and-load"](dir)
+  local config0 = _let_2_["config"]
+  local root_dir = _let_2_["root-dir"]
+  local cfg = _let_2_["cfg"]
+  if config0 then
+    local orphan_files = gc["find-orphan-lua-files"]({["root-dir"] = root_dir, cfg = cfg})
+    if core["empty?"](orphan_files) then
+      notify.info("No orphan files detected.")
+    else
+      local function _3_(f)
+        return (" - " .. f)
+      end
+      notify.warn("Orphan files detected, delete them with :NfnlDeleteOrphans.\n", str.join("\n", core.map(_3_, orphan_files)))
+    end
+    return orphan_files
+  else
+    notify.warn("No .nfnl.fnl configuration found.")
+    return {}
+  end
+end
+M["delete-orphans"] = function()
+  local dir = vim.fn.getcwd()
+  local _let_6_ = config["find-and-load"](dir)
+  local config0 = _let_6_["config"]
+  local root_dir = _let_6_["root-dir"]
+  local cfg = _let_6_["cfg"]
+  if config0 then
+    local orphan_files = gc["find-orphan-lua-files"]({["root-dir"] = root_dir, cfg = cfg})
+    if core["empty?"](orphan_files) then
+      notify.info("No orphan files detected.")
+    else
+      local function _7_(f)
+        return (" - " .. f)
+      end
+      notify.info("Deleting orphan files:\n", str.join("\n", core.map(_7_, orphan_files)))
+      core.map(os.remove, orphan_files)
+    end
+    return orphan_files
+  else
+    notify.warn("No .nfnl.fnl configuration found.")
+    return {}
+  end
+end
+M["compile-file"] = function(_10_)
+  local path = _10_["path"]
+  local dir = _10_["dir"]
   local dir0 = (dir or vim.fn.getcwd())
-  local _let_3_ = config["find-and-load"](dir0)
-  local config0 = _let_3_["config"]
-  local root_dir = _let_3_["root-dir"]
-  local cfg = _let_3_["cfg"]
+  local _let_11_ = config["find-and-load"](dir0)
+  local config0 = _let_11_["config"]
+  local root_dir = _let_11_["root-dir"]
+  local cfg = _let_11_["cfg"]
   if config0 then
     local path0 = fs["join-path"]({root_dir, vim.fn.expand((path or "%"))})
     local result = compile["into-file"]({["root-dir"] = root_dir, cfg = cfg, path = path0, source = core.slurp(path0), ["batch?"] = true})
@@ -28,10 +75,10 @@ M["compile-file"] = function(_2_)
 end
 M["compile-all-files"] = function(dir)
   local dir0 = (dir or vim.fn.getcwd())
-  local _let_5_ = config["find-and-load"](dir0)
-  local config0 = _let_5_["config"]
-  local root_dir = _let_5_["root-dir"]
-  local cfg = _let_5_["cfg"]
+  local _let_13_ = config["find-and-load"](dir0)
+  local config0 = _let_13_["config"]
+  local root_dir = _let_13_["root-dir"]
+  local cfg = _let_13_["cfg"]
   if config0 then
     local results = compile["all-files"]({["root-dir"] = root_dir, cfg = cfg})
     notify.info("Compilation complete.\n", results)

--- a/lua/nfnl/callback.lua
+++ b/lua/nfnl/callback.lua
@@ -53,7 +53,15 @@ local function fennel_filetype_callback(ev)
       local function _10_(_241)
         return api["compile-all-files"](core.first(core.get(_241, "fargs")))
       end
-      return vim.api.nvim_buf_create_user_command(ev.buf, "NfnlCompileAllFiles", _10_, {desc = "Executes (nfnl.api/compile-all-files) which will, you guessed it, compile all of your files.", force = true, complete = "file", nargs = "?"})
+      vim.api.nvim_buf_create_user_command(ev.buf, "NfnlCompileAllFiles", _10_, {desc = "Executes (nfnl.api/compile-all-files) which will, you guessed it, compile all of your files.", force = true, complete = "file", nargs = "?"})
+      local function _11_()
+        return api["find-orphans"]()
+      end
+      vim.api.nvim_buf_create_user_command(ev.buf, "NfnlFindOrphans", _11_, {desc = "Executes (nfnl.api/find-orphans) which will find and display all Lua files that no longer have a matching Fennel file.", force = true})
+      local function _12_()
+        return api["delete-orphans"]()
+      end
+      return vim.api.nvim_buf_create_user_command(ev.buf, "NfnlDeleteOrphans", _12_, {desc = "Executes (nfnl.api/delete-orphans) deletes any orphan Lua files that no longer have their original Fennel file they were compiled from.", force = true})
     else
       return nil
     end

--- a/lua/nfnl/callback.lua
+++ b/lua/nfnl/callback.lua
@@ -12,7 +12,7 @@ local notify = autoload("nfnl.notify")
 local function fennel_buf_write_post_callback_fn(root_dir, cfg)
   local function _2_(ev)
     compile["into-file"]({["root-dir"] = root_dir, cfg = cfg, path = fs["full-path"](ev.file), source = nvim["get-buf-content-as-string"](ev.buf)})
-    if cfg({"find-orphan-lua-files"}) then
+    if cfg({"orphan-detection", "auto?"}) then
       api["find-orphans"]({["passive?"] = true})
     else
     end

--- a/lua/nfnl/callback.lua
+++ b/lua/nfnl/callback.lua
@@ -12,27 +12,31 @@ local notify = autoload("nfnl.notify")
 local function fennel_buf_write_post_callback_fn(root_dir, cfg)
   local function _2_(ev)
     compile["into-file"]({["root-dir"] = root_dir, cfg = cfg, path = fs["full-path"](ev.file), source = nvim["get-buf-content-as-string"](ev.buf)})
+    if cfg({"find-orphan-lua-files"}) then
+      api["find-orphans"]({["passive?"] = true})
+    else
+    end
     return nil
   end
   return _2_
 end
 local function supported_path_3f(file_path)
-  local _3_
+  local _4_
   if core["string?"](file_path) then
-    _3_ = not file_path:find("^[%w-]+:/")
+    _4_ = not file_path:find("^[%w-]+:/")
   else
-    _3_ = nil
+    _4_ = nil
   end
-  return (_3_ or false)
+  return (_4_ or false)
 end
 local function fennel_filetype_callback(ev)
   local file_path = fs["full-path"](ev.file)
   if supported_path_3f(file_path) then
     local file_dir = fs.basename(file_path)
-    local _let_5_ = config["find-and-load"](file_dir)
-    local config0 = _let_5_["config"]
-    local root_dir = _let_5_["root-dir"]
-    local cfg = _let_5_["cfg"]
+    local _let_6_ = config["find-and-load"](file_dir)
+    local config0 = _let_6_["config"]
+    local root_dir = _let_6_["root-dir"]
+    local cfg = _let_6_["cfg"]
     if config0 then
       if cfg({"verbose"}) then
         notify.info("Found nfnl config, setting up autocmds: ", root_dir)
@@ -42,26 +46,26 @@ local function fennel_filetype_callback(ev)
         vim.api.nvim_create_autocmd({"BufWritePost"}, {group = vim.api.nvim_create_augroup(str.join({"nfnl-on-write", root_dir, ev.buf}), {}), buffer = ev.buf, callback = fennel_buf_write_post_callback_fn(root_dir, cfg)})
       else
       end
-      local function _8_(_241)
+      local function _9_(_241)
         return api.dofile(core.first(core.get(_241, "fargs")))
       end
-      vim.api.nvim_buf_create_user_command(ev.buf, "NfnlFile", _8_, {desc = "Run the matching Lua file for this Fennel file from disk. Does not recompile the Lua, you must use nfnl to compile your Fennel to Lua first. Calls nfnl.api/dofile under the hood.", force = true, complete = "file", nargs = "?"})
-      local function _9_(_241)
+      vim.api.nvim_buf_create_user_command(ev.buf, "NfnlFile", _9_, {desc = "Run the matching Lua file for this Fennel file from disk. Does not recompile the Lua, you must use nfnl to compile your Fennel to Lua first. Calls nfnl.api/dofile under the hood.", force = true, complete = "file", nargs = "?"})
+      local function _10_(_241)
         return api["compile-file"]({path = core.first(core.get(_241, "fargs"))})
       end
-      vim.api.nvim_buf_create_user_command(ev.buf, "NfnlCompileFile", _9_, {desc = "Executes (nfnl.api/compile-file) which compiles the current file or the one provided as an argumet. The output is written to the appropriate Lua file.", force = true, complete = "file", nargs = "?"})
-      local function _10_(_241)
+      vim.api.nvim_buf_create_user_command(ev.buf, "NfnlCompileFile", _10_, {desc = "Executes (nfnl.api/compile-file) which compiles the current file or the one provided as an argumet. The output is written to the appropriate Lua file.", force = true, complete = "file", nargs = "?"})
+      local function _11_(_241)
         return api["compile-all-files"](core.first(core.get(_241, "fargs")))
       end
-      vim.api.nvim_buf_create_user_command(ev.buf, "NfnlCompileAllFiles", _10_, {desc = "Executes (nfnl.api/compile-all-files) which will, you guessed it, compile all of your files.", force = true, complete = "file", nargs = "?"})
-      local function _11_()
+      vim.api.nvim_buf_create_user_command(ev.buf, "NfnlCompileAllFiles", _11_, {desc = "Executes (nfnl.api/compile-all-files) which will, you guessed it, compile all of your files.", force = true, complete = "file", nargs = "?"})
+      local function _12_()
         return api["find-orphans"]()
       end
-      vim.api.nvim_buf_create_user_command(ev.buf, "NfnlFindOrphans", _11_, {desc = "Executes (nfnl.api/find-orphans) which will find and display all Lua files that no longer have a matching Fennel file.", force = true})
-      local function _12_()
+      vim.api.nvim_buf_create_user_command(ev.buf, "NfnlFindOrphans", _12_, {desc = "Executes (nfnl.api/find-orphans) which will find and display all Lua files that no longer have a matching Fennel file.", force = true})
+      local function _13_()
         return api["delete-orphans"]()
       end
-      return vim.api.nvim_buf_create_user_command(ev.buf, "NfnlDeleteOrphans", _12_, {desc = "Executes (nfnl.api/delete-orphans) deletes any orphan Lua files that no longer have their original Fennel file they were compiled from.", force = true})
+      return vim.api.nvim_buf_create_user_command(ev.buf, "NfnlDeleteOrphans", _13_, {desc = "Executes (nfnl.api/delete-orphans) deletes any orphan Lua files that no longer have their original Fennel file they were compiled from.", force = true})
     else
       return nil
     end

--- a/lua/nfnl/compile.lua
+++ b/lua/nfnl/compile.lua
@@ -6,14 +6,11 @@ local fs = autoload("nfnl.fs")
 local fennel = autoload("nfnl.fennel")
 local notify = autoload("nfnl.notify")
 local config = autoload("nfnl.config")
+local header = autoload("nfnl.header")
 local mod = {}
-local header_marker = "[nfnl]"
-local function with_header(file, src)
-  return ("-- " .. header_marker .. " " .. file .. "\n" .. src)
-end
 local function safe_target_3f(path)
-  local header = fs["read-first-line"](path)
-  return (core["nil?"](header) or not core["nil?"](header:find(header_marker, 1, true)))
+  local line = fs["read-first-line"](path)
+  return (not line or header["tagged?"](line))
 end
 local function macro_source_3f(source)
   return string.find(source, "%s*;+%s*%[nfnl%-macro%]")
@@ -66,7 +63,7 @@ mod["into-string"] = function(_6_)
       end
       local _8_
       if cfg({"header-comment"}) then
-        _8_ = with_header(rel_file_name, res)
+        _8_ = header["with-header"](rel_file_name, res)
       else
         _8_ = res
       end

--- a/lua/nfnl/config.lua
+++ b/lua/nfnl/config.lua
@@ -51,7 +51,7 @@ local function default(opts)
   local function _13_(root_dir0)
     return core.map(fs["join-path"], {{root_dir0, "?.fnl"}, {root_dir0, "?", "init-macros.fnl"}, {root_dir0, "?", "init.fnl"}, {root_dir0, "fnl", "?.fnl"}, {root_dir0, "fnl", "?", "init-macros.fnl"}, {root_dir0, "fnl", "?", "init.fnl"}})
   end
-  return {["header-comment"] = true, ["find-orphan-lua-files"] = true, ["compiler-options"] = {["error-pinpoint"] = false}, ["root-dir"] = root_dir, ["fennel-path"] = str.join(";", core.mapcat(_12_, dirs)), ["fennel-macro-path"] = str.join(";", core.mapcat(_13_, dirs)), ["source-file-patterns"] = {".*.fnl", "*.fnl", fs["join-path"]({"**", "*.fnl"})}, ["fnl-path->lua-path"] = fs["fnl-path->lua-path"], verbose = false}
+  return {["header-comment"] = true, ["compiler-options"] = {["error-pinpoint"] = false}, ["orphan-detection"] = {["auto?"] = true, ["ignore-patterns"] = {}}, ["root-dir"] = root_dir, ["fennel-path"] = str.join(";", core.mapcat(_12_, dirs)), ["fennel-macro-path"] = str.join(";", core.mapcat(_13_, dirs)), ["source-file-patterns"] = {".*.fnl", "*.fnl", fs["join-path"]({"**", "*.fnl"})}, ["fnl-path->lua-path"] = fs["fnl-path->lua-path"], verbose = false}
 end
 local function cfg_fn(t, opts)
   local default_cfg = default(opts)

--- a/lua/nfnl/config.lua
+++ b/lua/nfnl/config.lua
@@ -51,7 +51,7 @@ local function default(opts)
   local function _13_(root_dir0)
     return core.map(fs["join-path"], {{root_dir0, "?.fnl"}, {root_dir0, "?", "init-macros.fnl"}, {root_dir0, "?", "init.fnl"}, {root_dir0, "fnl", "?.fnl"}, {root_dir0, "fnl", "?", "init-macros.fnl"}, {root_dir0, "fnl", "?", "init.fnl"}})
   end
-  return {["header-comment"] = true, ["compiler-options"] = {["error-pinpoint"] = false}, ["root-dir"] = root_dir, ["fennel-path"] = str.join(";", core.mapcat(_12_, dirs)), ["fennel-macro-path"] = str.join(";", core.mapcat(_13_, dirs)), ["source-file-patterns"] = {".*.fnl", "*.fnl", fs["join-path"]({"**", "*.fnl"})}, ["fnl-path->lua-path"] = fs["fnl-path->lua-path"], verbose = false}
+  return {["header-comment"] = true, ["find-orphan-lua-files"] = true, ["compiler-options"] = {["error-pinpoint"] = false}, ["root-dir"] = root_dir, ["fennel-path"] = str.join(";", core.mapcat(_12_, dirs)), ["fennel-macro-path"] = str.join(";", core.mapcat(_13_, dirs)), ["source-file-patterns"] = {".*.fnl", "*.fnl", fs["join-path"]({"**", "*.fnl"})}, ["fnl-path->lua-path"] = fs["fnl-path->lua-path"], verbose = false}
 end
 local function cfg_fn(t, opts)
   local default_cfg = default(opts)

--- a/lua/nfnl/foo.lua
+++ b/lua/nfnl/foo.lua
@@ -1,0 +1,2 @@
+-- [nfnl] fnl/nfnl/foo.fnl
+

--- a/lua/nfnl/foo.lua
+++ b/lua/nfnl/foo.lua
@@ -1,2 +1,0 @@
--- [nfnl] fnl/nfnl/foo.fnl
-

--- a/lua/nfnl/fs.lua
+++ b/lua/nfnl/fs.lua
@@ -116,9 +116,10 @@ M["glob-matches?"] = function(dir, expr, path)
   local regex = vim.regex(vim.fn.glob2regpat(M["join-path"]({dir, expr})))
   return regex:match_str(path)
 end
+local uv = (vim.uv or vim.loop)
 M["exists?"] = function(path)
   if path then
-    return ("table" == type(vim.uv.fs_stat(path)))
+    return ("table" == type(uv.fs_stat(path)))
   else
     return nil
   end

--- a/lua/nfnl/gc.lua
+++ b/lua/nfnl/gc.lua
@@ -5,14 +5,15 @@ local define = _local_1_["define"]
 local core = autoload("nfnl.core")
 local str = autoload("nfnl.string")
 local fs = autoload("nfnl.fs")
+local header = autoload("nfnl.header")
 local M = define("nfnl.gc")
 M["find-orphan-lua-files"] = function(_2_)
   local cfg = _2_["cfg"]
   local root_dir = _2_["root-dir"]
   local fnl_path__3elua_path = cfg({"fnl-path->lua-path"})
   local function _3_(path)
-    local header = fs["read-first-line"](path)
-    return (header and not core["nil?"](header:find("[nfnl]", 1, true)) and not vim.uv.fs_stat(core.last(str.split(path, "%s+"))))
+    local line = fs["read-first-line"](path)
+    return (header["tagged?"](line) and not fs["exists?"](header["source-path"](line)))
   end
   local function _4_(fnl_pattern)
     local lua_pattern = fnl_path__3elua_path(fnl_pattern)

--- a/lua/nfnl/gc.lua
+++ b/lua/nfnl/gc.lua
@@ -2,9 +2,23 @@
 local _local_1_ = require("nfnl.module")
 local autoload = _local_1_["autoload"]
 local define = _local_1_["define"]
+local core = autoload("nfnl.core")
+local str = autoload("nfnl.string")
 local fs = autoload("nfnl.fs")
 local M = define("nfnl.gc")
-M["find-orphan-lua-files"] = function()
-  return fs.relglob(".", "**/*.lua")
+M["find-orphan-lua-files"] = function(_2_)
+  local cfg = _2_["cfg"]
+  local root_dir = _2_["root-dir"]
+  local fnl_path__3elua_path = cfg({"fnl-path->lua-path"})
+  local function _3_(path)
+    local header = fs["read-first-line"](path)
+    return (header and not core["nil?"](header:find("[nfnl]", 1, true)) and not vim.uv.fs_stat(core.last(str.split(path, "%s+"))))
+  end
+  local function _4_(fnl_pattern)
+    local lua_pattern = fnl_path__3elua_path(fnl_pattern)
+    return fs.absglob(root_dir, lua_pattern)
+  end
+  return core.filter(_3_, core.keys(core["->set"](core.mapcat(_4_, cfg({"source-file-patterns"})))))
 end
+--[[ (local config (require "nfnl.config")) (M.find-orphan-lua-files (config.find-and-load ".")) ]]
 return M

--- a/lua/nfnl/gc.lua
+++ b/lua/nfnl/gc.lua
@@ -1,0 +1,7 @@
+-- [nfnl] fnl/nfnl/gc.fnl
+local _local_1_ = require("nfnl.module")
+local autoload = _local_1_["autoload"]
+local define = _local_1_["define"]
+local fs = autoload("nfnl.fs")
+local M = define("nfnl.gc")
+return M

--- a/lua/nfnl/gc.lua
+++ b/lua/nfnl/gc.lua
@@ -3,7 +3,6 @@ local _local_1_ = require("nfnl.module")
 local autoload = _local_1_["autoload"]
 local define = _local_1_["define"]
 local core = autoload("nfnl.core")
-local str = autoload("nfnl.string")
 local fs = autoload("nfnl.fs")
 local header = autoload("nfnl.header")
 local M = define("nfnl.gc")
@@ -17,7 +16,7 @@ M["find-orphan-lua-files"] = function(_2_)
   end
   local function _4_(fnl_pattern)
     local lua_pattern = fnl_path__3elua_path(fnl_pattern)
-    return fs.absglob(root_dir, lua_pattern)
+    return fs.relglob(root_dir, lua_pattern)
   end
   return core.filter(_3_, core.keys(core["->set"](core.mapcat(_4_, cfg({"source-file-patterns"})))))
 end

--- a/lua/nfnl/gc.lua
+++ b/lua/nfnl/gc.lua
@@ -4,4 +4,7 @@ local autoload = _local_1_["autoload"]
 local define = _local_1_["define"]
 local fs = autoload("nfnl.fs")
 local M = define("nfnl.gc")
+M["find-orphan-lua-files"] = function()
+  return fs.relglob(".", "**/*.lua")
+end
 return M

--- a/lua/nfnl/gc.lua
+++ b/lua/nfnl/gc.lua
@@ -10,15 +10,19 @@ M["find-orphan-lua-files"] = function(_2_)
   local cfg = _2_["cfg"]
   local root_dir = _2_["root-dir"]
   local fnl_path__3elua_path = cfg({"fnl-path->lua-path"})
+  local ignore_patterns = cfg({"orphan-detection", "ignore-patterns"})
   local function _3_(path)
     local line = fs["read-first-line"](path)
-    return (header["tagged?"](line) and not fs["exists?"](header["source-path"](line)))
+    local function _4_(pat)
+      return path:find(pat)
+    end
+    return (not core.some(_4_, ignore_patterns) and header["tagged?"](line) and not fs["exists?"](header["source-path"](line)))
   end
-  local function _4_(fnl_pattern)
+  local function _5_(fnl_pattern)
     local lua_pattern = fnl_path__3elua_path(fnl_pattern)
     return fs.relglob(root_dir, lua_pattern)
   end
-  return core.filter(_3_, core.keys(core["->set"](core.mapcat(_4_, cfg({"source-file-patterns"})))))
+  return core.filter(_3_, core.keys(core["->set"](core.mapcat(_5_, cfg({"source-file-patterns"})))))
 end
 --[[ (local config (require "nfnl.config")) (M.find-orphan-lua-files (config.find-and-load ".")) ]]
 return M

--- a/lua/nfnl/header.lua
+++ b/lua/nfnl/header.lua
@@ -3,12 +3,20 @@ local _local_1_ = require("nfnl.module")
 local autoload = _local_1_["autoload"]
 local define = _local_1_["define"]
 local core = autoload("nfnl.core")
+local str = autoload("nfnl.string")
 local M = define("nfnl.header")
 local tag = "[nfnl]"
 M["with-header"] = function(file, src)
   return ("-- " .. tag .. " " .. file .. "\n" .. src)
 end
 M["tagged?"] = function(s)
-  return core["string?"](s:find(tag, 1, true))
+  return core["number?"](s:find(tag, 1, true))
+end
+M["source-path"] = function(s)
+  if M["tagged?"](s) then
+    return core.last(str.split(s, "%s+"))
+  else
+    return nil
+  end
 end
 return M

--- a/lua/nfnl/header.lua
+++ b/lua/nfnl/header.lua
@@ -14,7 +14,10 @@ M["tagged?"] = function(s)
 end
 M["source-path"] = function(s)
   if M["tagged?"](s) then
-    return core.last(str.split(s, "%s+"))
+    local function _2_(part)
+      return (str["ends-with?"](part, ".fnl") and part)
+    end
+    return core.some(_2_, str.split(s, "%s+"))
   else
     return nil
   end

--- a/lua/nfnl/header.lua
+++ b/lua/nfnl/header.lua
@@ -1,0 +1,14 @@
+-- [nfnl] fnl/nfnl/header.fnl
+local _local_1_ = require("nfnl.module")
+local autoload = _local_1_["autoload"]
+local define = _local_1_["define"]
+local core = autoload("nfnl.core")
+local M = define("nfnl.header")
+local tag = "[nfnl]"
+M["with-header"] = function(file, src)
+  return ("-- " .. tag .. " " .. file .. "\n" .. src)
+end
+M["tagged?"] = function(s)
+  return core["string?"](s:find(tag, 1, true))
+end
+return M

--- a/lua/spec/nfnl/macros/aniseed_spec.lua
+++ b/lua/spec/nfnl/macros/aniseed_spec.lua
@@ -1,4 +1,4 @@
--- [nfnl] Compiled from fnl/spec/nfnl/macros/aniseed_spec.fnl by https://github.com/Olical/nfnl, do not edit.
+-- [nfnl] fnl/spec/nfnl/macros/aniseed_spec.fnl
 local _local_1_ = require("plenary.busted")
 local describe = _local_1_["describe"]
 local it = _local_1_["it"]
@@ -78,4 +78,12 @@ local function _10_()
   end
   return it("defines private once values", _11_)
 end
-return describe("defonce-", _10_)
+describe("defonce-", _10_)
+local function _12_()
+  local function _13_()
+    assert.equals("this is public once val", public_once_val0)
+    return assert.equals("this is public once val", mod["public-once-val"])
+  end
+  return it("defines public once values", _13_)
+end
+return describe("defonce", _12_)

--- a/plugin/nfnl.fnl
+++ b/plugin/nfnl.fnl
@@ -1,0 +1,1 @@
+(require "nfnl")

--- a/plugin/nfnl.lua
+++ b/plugin/nfnl.lua
@@ -1,0 +1,2 @@
+-- [nfnl] plugin/nfnl.fnl
+return require("nfnl")

--- a/plugin/nfnl.vim
+++ b/plugin/nfnl.vim
@@ -1,1 +1,0 @@
-lua require('nfnl')


### PR DESCRIPTION
#48

This finds files that match your Lua file glob patterns in `.nfnl.fnl` and checks a few things:

 - Do they have a `[nfnl]` header that indicates that this file was compiled by nfnl?
 - If it does, get the path to the source file from that header (which I recently simplified)
 - Does that source Fennel file exist?
 - If it doesn't, prompt to delete the Lua file since the file it was compiled from is no longer there.

I've tried to make this as efficient as I can, there's a risk that all this fs access on each write will be slow for some users. So we should run it in another thread / off of the main UI thread somehow and make it controllable so the user can turn it off per project.

It only reads the first line from each file and only the files that match the patterns in the configuration. Hopefully this should keep slowdowns to a minimum.

## Try it!

Use `:NfnlFindOrphans` and then if you're happy, `:NfnlDeleteOrphans`. I'll automate it next with config options to turn it off.

## To Do

- [x] Have it actually prompt to delete the orphaned files whenever we compile something or compile all files (only run this once if we compile all files!)
- [x] Add a section to the config so you can manually exclude some files from this deletion system. I doubt people will need this, but I want to provide it.
- [x] Add a flag to turn the GC system on and off.
- [x] Have a command users can invoke manually if they turn off the auto cleanup.